### PR TITLE
Try to wrap Engine compile function

### DIFF
--- a/lib/rhai/ast.ex
+++ b/lib/rhai/ast.ex
@@ -1,0 +1,26 @@
+defmodule Rhai.AST do
+  @moduledoc """
+  Compiled AST (abstract syntax tree) of a Rhai script.
+  """
+
+  defstruct [
+    # The actual NIF Resource.
+    resource: nil,
+
+    # Normally the compiler will happily do stuff like inlining the
+    # resource in attributes. This will convert the resource into an
+    # empty binary with no warning. This will make that harder to
+    # accidentaly do.
+    # It also serves as a handy way to tell file handles apart.
+    reference: nil
+  ]
+
+  @type t :: %__MODULE__{}
+
+  def wrap_resource(resource) do
+    %__MODULE__{
+      resource: resource,
+      reference: make_ref()
+    }
+  end
+end

--- a/lib/rhai/native.ex
+++ b/lib/rhai/native.ex
@@ -29,6 +29,7 @@ defmodule Rhai.Native do
   def eval(_, _), do: err()
   # engine
   def engine_new, do: err()
+  def engine_compile(_engine, _script), do: err()
   def engine_eval(_engine, _script), do: err()
   def engine_set_fail_on_invalid_map_property(_engine, _flag), do: err()
   def engine_fail_on_invalid_map_property(_engine), do: err()

--- a/native/rhai_rustler/src/ast.rs
+++ b/native/rhai_rustler/src/ast.rs
@@ -1,7 +1,7 @@
-use std::sync::Mutex;
+use std::sync::RwLock;
 
 use rhai::AST;
 
 pub struct ASTResource {
-    pub ast: Mutex<AST>,
+    pub ast: RwLock<AST>,
 }

--- a/native/rhai_rustler/src/ast.rs
+++ b/native/rhai_rustler/src/ast.rs
@@ -1,0 +1,7 @@
+use std::sync::Mutex;
+
+use rhai::AST;
+
+pub struct ASTResource {
+    pub ast: Mutex<AST>,
+}

--- a/native/rhai_rustler/src/engine.rs
+++ b/native/rhai_rustler/src/engine.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 
 use rhai::{Dynamic, Engine};
 use rustler::{Encoder, Env, ResourceArc, Term};
@@ -45,7 +45,7 @@ fn engine_compile<'a>(
     match engine.compile(script) {
         Ok(result) => {
             let ast_resource = ResourceArc::new(ASTResource {
-                ast: Mutex::new(result),
+                ast: RwLock::new(result),
             });
             Ok(ast_resource)
         }

--- a/native/rhai_rustler/src/engine.rs
+++ b/native/rhai_rustler/src/engine.rs
@@ -1,19 +1,16 @@
 use std::sync::Mutex;
 
-use rhai::{Dynamic, Engine, AST};
+use rhai::{Dynamic, Engine};
 use rustler::{Encoder, Env, ResourceArc, Term};
 
 use crate::{
+    ast::ASTResource,
     errors::{atoms, to_error},
     types::from_dynamic,
 };
 
 pub struct EngineResource {
     pub engine: Mutex<Engine>,
-}
-
-pub struct ASTResource {
-    pub ast: Mutex<AST>,
 }
 
 #[rustler::nif]

--- a/native/rhai_rustler/src/errors.rs
+++ b/native/rhai_rustler/src/errors.rs
@@ -1,7 +1,7 @@
 use rhai::EvalAltResult;
 use rustler::{Encoder, Env, Term};
 
-mod atoms {
+pub mod atoms {
     rustler::atoms! {
         system,
         parsing,

--- a/native/rhai_rustler/src/lib.rs
+++ b/native/rhai_rustler/src/lib.rs
@@ -36,6 +36,7 @@ fn eval<'a>(
 
 fn load(env: Env, _: Term) -> bool {
     rustler::resource!(EngineResource, env);
+    rustler::resource!(ASTResource, env);
     true
 }
 

--- a/native/rhai_rustler/src/lib.rs
+++ b/native/rhai_rustler/src/lib.rs
@@ -48,6 +48,7 @@ rustler::init!(
         // legacy
         eval,
         // engine
+        engine_compile,
         engine_new,
         engine_eval,
         engine_set_fail_on_invalid_map_property,

--- a/native/rhai_rustler/src/lib.rs
+++ b/native/rhai_rustler/src/lib.rs
@@ -1,3 +1,4 @@
+mod ast;
 mod engine;
 mod errors;
 mod types;
@@ -7,6 +8,7 @@ use std::collections::HashMap;
 use rhai::{Dynamic, Engine, Scope};
 use rustler::{Env, Term};
 
+use crate::ast::*;
 use crate::engine::*;
 
 #[rustler::nif]

--- a/test/rhai/engine_test.exs
+++ b/test/rhai/engine_test.exs
@@ -30,4 +30,18 @@ defmodule Rhai.EngineTest do
              |> Engine.fail_on_invalid_map_property?()
     end
   end
+
+  describe "compile/2" do
+    test "should compile a valid expression into AST" do
+      engine = Engine.new()
+
+      assert {:ok, %Rhai.AST{}} = Engine.compile(engine, "1+1")
+    end
+
+    test "should not compile an invalid expression" do
+      engine = Engine.new()
+
+      assert {:error, {:parsing, "parsing error"}}
+    end
+  end
 end

--- a/test/rhai/engine_test.exs
+++ b/test/rhai/engine_test.exs
@@ -41,7 +41,7 @@ defmodule Rhai.EngineTest do
     test "should not compile an invalid expression" do
       engine = Engine.new()
 
-      assert {:error, {:parsing, "parsing error"}}
+      assert {:error, {:parsing, "parsing error"}} == Engine.compile(engine, "???")
     end
   end
 end


### PR DESCRIPTION
As above, I'm trying to just wrap `engine.compile()`.